### PR TITLE
Attempt to reconnect after connection loss

### DIFF
--- a/scripts/modbus_device_driver.py
+++ b/scripts/modbus_device_driver.py
@@ -7,6 +7,7 @@ import logging
 import rospy
 
 from ros_modbus_device import *
+from pymodbus.exceptions import ConnectionException
 
 
 logger = logging.getLogger(__name__)
@@ -23,9 +24,15 @@ rospy.init_node('modbus_device_driver', anonymous=True)
 modbus_device = ROSModbusSlaveDevice()
 
 logger.info("connecting to: %s:%d", modbus_device.config.config['address'], modbus_device.config.config['port'])
-while not modbus_device.connect() and not rospy.is_shutdown():
-    rospy.sleep(1)
-    logger.info("Retrying connecting to: %s:%d", modbus_device.config.config['address'], modbus_device.config.config['port'])
-    
-if not rospy.is_shutdown():
-    modbus_device.run()
+while not rospy.is_shutdown():
+    while not modbus_device.connect() and not rospy.is_shutdown():
+        rospy.sleep(1)
+        logger.info("Retrying connecting to: %s:%d", modbus_device.config.config['address'], modbus_device.config.config['port'])
+        
+    if not rospy.is_shutdown():
+        try:
+            modbus_device.run()
+        except ConnectionException as err:
+            logger.error("Lost connection! Error message: {}".format(err))
+            rospy.sleep(1)
+            logger.info("Attempting to reestablish connection to: %s:%d", modbus_device.config.config['address'], modbus_device.config.config['port'])

--- a/scripts/modbus_device_driver.py
+++ b/scripts/modbus_device_driver.py
@@ -25,7 +25,7 @@ modbus_device = ROSModbusSlaveDevice()
 logger.info("connecting to: %s:%d", modbus_device.config.config['address'], modbus_device.config.config['port'])
 while not modbus_device.connect() and not rospy.is_shutdown():
     rospy.sleep(1)
-    print('.', end='', flush=True)
+    logger.info("Retrying connecting to: %s:%d", modbus_device.config.config['address'], modbus_device.config.config['port'])
     
 if not rospy.is_shutdown():
     modbus_device.run()

--- a/src/ros_modbus_device/slave_device_config.py
+++ b/src/ros_modbus_device/slave_device_config.py
@@ -73,6 +73,7 @@ class ROSModbusSlaveDeviceConfig:
             with open(path) as file:
                 logger.info("successfully opened: %s", path)
                 return yaml.safe_load(file)
-        except:
+        except BaseException as err:
             logger.error("could not open or read a config/mapping file at '%s'", path)
+            logger.error("Unexpected error: {}".format(err))
             sys.exit(-1)


### PR DESCRIPTION
In case of a temporary connection drop, we attempt to reestablish the connection.

Also removed an instance of `print('.', end='', flush=True)` which breaks on python2.